### PR TITLE
Handle extra attributes in element 'a'

### DIFF
--- a/reconciliation.py
+++ b/reconciliation.py
@@ -111,7 +111,7 @@ class SearchLoC:
         id_pairs = []
         for r in results:
             heading = re.search("\">(.+)</a></td>", r).group(1)
-            term_id = re.search("<td><a href=\"/authorities" + self.term_type + "/(.+)\">", r).group(1)
+            term_id = re.search("<td><a href=\"/authorities" + self.term_type + "/([^\"]+)\"[^>]*>", r).group(1)
             term_id = self.get_term_uri(term_id)
             if term_id and heading:
                 id_pairs.append((heading, term_id))


### PR DESCRIPTION
The response coming back from LoC is looking like this:
`<td><a href="/authorities/term_id_is_here" title="Click to view record">`
instead of like this:
`<td><a href="/authorities/term_id_is_here">`
so the term_id is getting set to:
`term_id_is_here" title="Click to view record`
because the regex `"/(.+)\">"` is greedily taking everything up to the last `"` before the `>`.

This commit changes the regex to `"/([^\"]+)\"[^>]*>"` which searches for `/`, followed by
one or more characters that are not `"`, followed by `"`, followed by zero or more characters
that are not `>`, followed by `>`. The group will now take only up to the first double quote
character, so it will work no matter what other attributes are within the `<a>` element.